### PR TITLE
chore: tests

### DIFF
--- a/packages/reactivity/__tests__/reactive.spec.ts
+++ b/packages/reactivity/__tests__/reactive.spec.ts
@@ -272,7 +272,7 @@ describe('reactivity/reactive', () => {
     const observed = reactive(original)
     expect(isReactive(observed)).toBe(false)
   })
-  test('should observe redefined property', () => {
+   test('should observe redefined property', () => {
     const foo = reactive({ bar: 0 })
     const trigger = vi.fn(() => {
       foo.bar
@@ -296,7 +296,7 @@ describe('reactivity/reactive', () => {
       },
       configurable: true
     })
-    expect(trigger).toHaveBeenCalledTimes(3)
+    expect(trigger).toHaveBeenCalledTimes(2)
     expect(foo.bar).toBe(456)
 
     // should not trigger on same value
@@ -306,6 +306,7 @@ describe('reactivity/reactive', () => {
       },
       configurable: true
     })
-    expect(trigger).toHaveBeenCalledTimes(3)
+    expect(trigger).toHaveBeenCalledTimes(2)
+    expect(foo.bar).toBe(456)
   })
 })


### PR DESCRIPTION
重新构建test流程，之间触发有问题，get不应该在defineProperty函数中触发，和原始Object.defineProperty()行为违背了